### PR TITLE
Pin to astroid==1.3.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+astroid==1.3.8
 pylint==1.4.4
 pytest==2.7.3
 pytest-gitignore==1.3


### PR DESCRIPTION
Fixes sudden build break with recently published astroid 1.4.{0,1}. Not sure what's wrong.
