### PR TITLE
Avoid importing the package in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,34 @@
-'''tldextract setup.py'''
+"""`tldextract` accurately separates the gTLD or ccTLD (generic or country code
+top-level domain) from the registered domain and subdomains of a URL.
+
+    >>> import tldextract
+    >>> tldextract.extract('http://forums.news.cnn.com/')
+    ExtractResult(subdomain='forums.news', domain='cnn', suffix='com')
+    >>> tldextract.extract('http://forums.bbc.co.uk/') # United Kingdom
+    ExtractResult(subdomain='forums', domain='bbc', suffix='co.uk')
+    >>> tldextract.extract('http://www.worldbank.org.kg/') # Kyrgyzstan
+    ExtractResult(subdomain='www', domain='worldbank', suffix='org.kg')
+
+`ExtractResult` is a namedtuple, so it's simple to access the parts you want.
+
+    >>> ext = tldextract.extract('http://forums.bbc.co.uk')
+    >>> (ext.subdomain, ext.domain, ext.suffix)
+    ('forums', 'bbc', 'co.uk')
+    >>> # rejoin subdomain and domain
+    >>> '.'.join(ext[:2])
+    'forums.bbc'
+    >>> # a common alias
+    >>> ext.registered_domain
+    'bbc.co.uk'
+"""
 
 import re
 import sys
 from setuptools import setup
-import tldextract
 
 # I don't want to learn reStructuredText right now, so strip Markdown links
 # that make pip barf.
-LONG_DESCRIPTION_MD = tldextract.tldextract.__doc__
+LONG_DESCRIPTION_MD = __doc__
 LONG_DESCRIPTION = re.sub(r'(?s)\[(.*?)\]\((http.*?)\)', r'\1', LONG_DESCRIPTION_MD)
 
 INSTALL_REQUIRES = ["setuptools"]
@@ -16,7 +37,7 @@ if (2, 7) > sys.version_info:
 
 setup(
     name="tldextract",
-    version=tldextract.__version__,
+    version="1.7.2",
     author="John Kurkowski",
     author_email="john.kurkowski@gmail.com",
     description=("Accurately separate the TLD from the registered domain and"

--- a/tldextract/__init__.py
+++ b/tldextract/__init__.py
@@ -1,5 +1,10 @@
 """Export tldextract's public interface."""
 
+import pkg_resources
+
 from .tldextract import extract, TLDExtract
 
-__version__ = "1.7.2"
+try:
+    __version__ = pkg_resources.get_distribution('tldextract').version # pylint: disable=no-member
+except pkg_resources.DistributionNotFound as _:
+    __version__ = '(local)'

--- a/tldextract/tldextract.py
+++ b/tldextract/tldextract.py
@@ -435,12 +435,15 @@ def main():
 
     logging.basicConfig()
 
-    distribution = pkg_resources.get_distribution('tldextract')
+    try:
+        __version__ = pkg_resources.get_distribution('tldextract').version # pylint: disable=no-member
+    except pkg_resources.DistributionNotFound as _:
+        __version__ = '(local)'
 
     parser = argparse.ArgumentParser(
         description='Parse hostname from a url or fqdn')
 
-    parser.add_argument('--version', action='version', version='%(prog)s ' + distribution.version) # pylint: disable=no-member
+    parser.add_argument('--version', action='version', version='%(prog)s ' + __version__) # pylint: disable=no-member
     parser.add_argument('input', metavar='fqdn|url',
                         type=unicode, nargs='*', help='fqdn or url')
 


### PR DESCRIPTION
Make setup.py the SPOT for **version**. Duplicate main module docstring, with tests, in setup.py. Duplication is a small price to pay for letting setup.py run smoothly. Fixes setup.py importing dependencies before it installs them. Unblocks #82.
